### PR TITLE
Workaround because com.palantir.conjure.java.runtime:conjure-java-jac…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,17 @@
             <groupId>com.palantir.docker.compose</groupId>
             <artifactId>docker-compose-rule-core</artifactId>
             <version>1.5.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.palantir.conjure.java.runtime</groupId>
+                    <artifactId>conjure-java-jackson-serialization</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.palantir.conjure.java.runtime</groupId>
+            <artifactId>conjure-java-jackson-serialization</artifactId>
+            <version>7.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
…kson-serialization:jar:4.18.1 isn't published to maven. Fixes #8.